### PR TITLE
add krypton remove alternate current

### DIFF
--- a/mods.json
+++ b/mods.json
@@ -46,11 +46,6 @@
 			"download_link": "https://cdn.modrinth.com/data/AANobbMI/versions/Nr39FOaS/sodium-fabric-mc1.19.3-0.4.6%2Bbuild.20.jar"
 		},
 		{
-			"slug": "alternate-current",
-			"version": "1.4.0",
-			"download_link": "https://cdn.modrinth.com/data/r0v8vy1s/versions/mc1.19-1.4.0/alternate-current-mc1.19-1.4.0.jar"
-		},
-		{
 			"slug": "better-biome-blend",
 			"version": "1.3.6",
 			"download_link": "https://cdn.modrinth.com/data/Rs6c7WyL/versions/1.19.0-1.3.6/betterbiomeblend-1.19.0-1.3.6-fabric.jar"
@@ -99,6 +94,11 @@
 			"slug": "yacl",
 			"version": "2.2.0",
 			"download_link": "https://cdn.modrinth.com/data/1eAoo2KR/versions/3EWbdCzX/YetAnotherConfigLib-2.2.0.jar"
+		},
+		{
+			"slug": "krypton",
+			"version": "0.2.1",
+			"download_link": "https://cdn.modrinth.com/data/fQEb0iXm/versions/0.2.1/krypton-0.2.1.jar"
 		}
 
 	],
@@ -149,11 +149,6 @@
 			"download_link": "https://cdn.modrinth.com/data/AANobbMI/versions/mc1.18.2-0.4.1/sodium-fabric-mc1.18.2-0.4.1%2Bbuild.15.jar"
 		},
 		{
-			"slug": "alternate-current",
-			"version": "1.4.0",
-			"download_link": "https://cdn.modrinth.com/data/r0v8vy1s/versions/mc1.18-1.4.0/alternate-current-mc1.18-1.4.0.jar"
-		},
-		{
 			"slug": "better-biome-blend",
 			"version": "1.3.5",
 			"download_link": "https://cdn.modrinth.com/data/Rs6c7WyL/versions/1.18.2-1.3.5-fabric/betterbiomeblend-1.18.2-1.3.5-fabric.jar"
@@ -197,6 +192,11 @@
 			"slug": "tweakeroo",
 			"version": "0.13.3",
 			"download_link": "https://www.curseforge.com/minecraft/mc-mods/tweakeroo/download/3783910/file"
+		},
+		{
+			"slug": "krypton",
+			"version": "0.1.9",
+			"download_link": "https://cdn.modrinth.com/data/fQEb0iXm/versions/0.1.9/krypton-0.1.9.jar"
 		}
 	]
 }


### PR DESCRIPTION
add krypton for network stack improvements, remove alternate current because it may cause issues with redstone that only works on vanilla.