### PR TITLE
Add new JVM launch options

### DIFF
--- a/src/main/java/pojlib/util/JREUtils.java
+++ b/src/main/java/pojlib/util/JREUtils.java
@@ -197,7 +197,10 @@ public class JREUtils {
 
         userArgs.add("-XX:+UseZGC");
         userArgs.add("-XX:+ZGenerational");
-
+        userArgs.add("-XX:+UnlockExperimentalVMOptions");
+        userArgs.add("-XX:+UnlockDiagnosticVMOptions");
+        userArgs.add("-XX:+DisableExplicitGC");
+        userArgs.add("-XX:+UseCriticalJavaThreadPriority");
         userArgs.add("-Dorg.lwjgl.opengl.libname=" + graphicsLib);
         userArgs.add("-Dorg.lwjgl.opengles.libname=" + "/system/lib64/libGLESv3.so");
         userArgs.add("-Dorg.lwjgl.egl.libname=" + "/system/lib64/libEGL_dri.so");


### PR DESCRIPTION
Why: JVM at the moment, (the one that you can actually see GC in f3) is fine but can be better, this update does quite a bit with only a couple launch arguments.
Mod Incompatibilities: Almost none or zero, used in a 500 mod modpack.

Improvements: The JVM is a lot less volatile and only GC's at the end of 3gb of ram on Q3 (2933mb)
Stutters are a lot shorter and thus, feel better.