### PR TITLE
Embeddium X JVM Update

### DIFF
--- a/devmods.json
+++ b/devmods.json
@@ -17,8 +17,8 @@
 			"defaultMods": [
 				{
 					"slug": "Sodium",
-					"version": "0.5.8",
-					"download_link": "https://github.com/QuestCraftPlusPlus/sodium-fabric/releases/download/mc1.20.4-0.5.8/sodium-fabric-0.5.8+mc1.20.4.jar"
+					"version": "0.3.14",
+					"download_link": "https://cdn.modrinth.com/data/sk9rgfiA/versions/RHVugIok/embeddium-fabric-0.3.14%2Bmc1.20.4.jar"
 				},
 				{
 					"slug": "Cloth-Config",
@@ -49,6 +49,31 @@
 					"slug": "Modern-Fix",
 					"version": "5.10.0",
 					"download_link": "https://cdn.modrinth.com/data/nmDcB62a/versions/vxDb5tOq/modernfix-fabric-5.10.0%2Bmc1.20.3.jar"
+				},
+				{
+					"slug": "Noisium",
+					"version": "2.0.3",
+					"download_link": "https://cdn.modrinth.com/data/KuNKN7d2/versions/Eie3f6ki/noisium-fabric-2.0.3%2Bmc1.20.2-1.20.4.jar"
+				},
+				{
+					"slug": "Lithium",
+					"version": "0.12.1",
+					"download_link": "https://cdn.modrinth.com/data/gvQqBUqZ/versions/nMhjKWVE/lithium-fabric-mc1.20.4-0.12.1.jar"
+				},
+				{
+					"slug": "EntityCulling",
+					"version": "1.6.5",
+					"download_link": "https://cdn.modrinth.com/data/NNAgCjsB/versions/hyejM5za/entityculling-fabric-1.6.5-mc1.20.4.jar"
+				},
+				{
+					"slug": "Ferrite-Core",
+					"version": "6.0.3",
+					"download_link": "https://cdn.modrinth.com/data/uXXizFIs/versions/pguEMpy9/ferritecore-6.0.3-fabric.jar"
+				},
+				{
+					"slug": "Krypton",
+					"version": "0.2.6",
+					"download_link": "https://cdn.modrinth.com/data/fQEb0iXm/versions/bRcuOnao/krypton-0.2.6.jar"
 				}
 			]
 		},
@@ -108,11 +133,6 @@
 					"download_link": "https://cdn.modrinth.com/data/4WWQxlQP/versions/wgjsjWPu/servercore-fabric-1.5.0%2B1.20.2.jar"
 				},
 				{
-					"slug": "Mod-Menu",
-					"version": "8.0.0",
-					"download_link": "https://cdn.modrinth.com/data/mOgUt4GM/versions/TwfjidT5/modmenu-8.0.0.jar"
-				},
-				{
 					"slug": "ImmediatelyFast",
 					"version": "1.2.6",
 					"download_link": "https://cdn.modrinth.com/data/5ZwdcRci/versions/mbeaDZtb/ImmediatelyFast-1.2.6%2B1.20.2.jar"
@@ -126,6 +146,11 @@
 					"slug": "Modern-Fix",
 					"version": "5.9.0",
 					"download_link": "https://cdn.modrinth.com/data/nmDcB62a/versions/FDGaMHFj/modernfix-fabric-5.9.0%2Bmc1.20.1.jar"
+				},
+				{
+					"slug": "Noisium",
+					"version": "2.0.2",
+					"download_link": "https://cdn.modrinth.com/data/KuNKN7d2/versions/ZgEmwDsG/noisium-fabric-2.0.2%2Bmc1.20.2-1.20.4.jar"
 				}
 			]
 		},
@@ -151,8 +176,8 @@
 				},
 				{
 					"slug": "Ferrite-Core",
-					"version": "6.0.0",
-					"download_link": "https://cdn.modrinth.com/data/uXXizFIs/versions/FCnCG6PS/ferritecore-6.0.0-fabric.jar"
+					"version": "6.0.1",
+					"download_link": "https://cdn.modrinth.com/data/uXXizFIs/versions/unerR5MN/ferritecore-6.0.1-fabric.jar"
 				},
 				{
 					"slug": "Entity-Culling",
@@ -161,8 +186,8 @@
 				},
 				{
 					"slug": "Sodium",
-					"version": "0.5.8",
-					"download_link": "https://github.com/QuestCraftPlusPlus/sodium-fabric/releases/download/mc1.20.1-0.5.8/sodium-fabric-0.5.8+mc1.20.1.jar"
+					"version": "0.3.19",
+					"download_link": "https://cdn.modrinth.com/data/sk9rgfiA/versions/Xg1M092Q/embeddium-fabric-0.3.19%2Bmc1.20.1.jar"
 				},
 				{
 					"slug": "Cloth-Config",
@@ -190,11 +215,6 @@
 					"download_link": "https://cdn.modrinth.com/data/4WWQxlQP/versions/dXmFuxyH/servercore-fabric-1.5.0%2B1.20.1.jar"
 				},
 				{
-					"slug": "Mod-Menu",
-					"version": "7.0.1",
-					"download_link": "https://cdn.modrinth.com/data/mOgUt4GM/versions/RTFDnTKf/modmenu-7.0.1.jar"
-				},
-				{
 					"slug": "ImmediatelyFast",
 					"version": "1.1.15",
 					"download_link": "https://cdn.modrinth.com/data/5ZwdcRci/versions/4IDo27OL/ImmediatelyFast-1.1.15%2B1.20.1.jar"
@@ -208,6 +228,11 @@
 					"slug": "Modern-Fix",
 					"version": "5.9.0",
 					"download_link": "https://cdn.modrinth.com/data/nmDcB62a/versions/FDGaMHFj/modernfix-fabric-5.9.0%2Bmc1.20.1.jar"
+				},
+				{
+					"slug": "Noisium",
+					"version": "2.0.3",
+					"download_link": "https://cdn.modrinth.com/data/KuNKN7d2/versions/uTdy9g9c/noisium-fabric-2.0.3%2Bmc1.20-1.20.1.jar"
 				}
 			]
 		},
@@ -292,19 +317,9 @@
 					"download_link": "https://cdn.modrinth.com/data/4WWQxlQP/versions/aq6o4qRe/servercore-1.3.5-1.19.4.jar"
 				},
 				{
-					"slug": "Mod-Menu",
-					"version": "6.2.1",
-					"download_link": "https://cdn.modrinth.com/data/mOgUt4GM/versions/yjjsLqbS/modmenu-6.2.1.jar"
-				},
-				{
 					"slug": "ImmediatelyFast",
 					"version": "1.1.12",
 					"download_link": "https://cdn.modrinth.com/data/5ZwdcRci/versions/8IFFeKYy/ImmediatelyFast-1.1.12%2B1.19.4.jar"
-				},
-				{
-					"slug": "Noxesium",
-					"version": "0.1.8",
-					"download_link": "https://cdn.modrinth.com/data/Kw7Sm3Xf/versions/5QKzTtlI/noxesium-0.1.8.jar"
 				},
 				{
 					"slug": "Modern-Fix",
@@ -379,11 +394,6 @@
 					"download_link": "https://cdn.modrinth.com/data/fQEb0iXm/versions/0.2.1/krypton-0.2.1.jar"
 				},
 				{
-					"slug": "Mod_Menu",
-					"version": "4.2.0-beta.2",
-					"download_link": "https://cdn.modrinth.com/data/mOgUt4GM/versions/gSoPJyVn/modmenu-4.2.0-beta.2.jar"
-				},
-				{
 					"slug": "Better-Biome-Blend",
 					"version": "1.3.6",
 					"download_link": "https://cdn.modrinth.com/data/Rs6c7WyL/versions/1.19.0-1.3.6/betterbiomeblend-1.19.0-1.3.6-fabric.jar"
@@ -392,11 +402,6 @@
 					"slug": "ImmediatelyFast",
 					"version": "1.1.12",
 					"download_link": "https://cdn.modrinth.com/data/5ZwdcRci/versions/4yVqQKQO/ImmediatelyFast-1.1.12%2B1.19.jar"
-				},
-				{
-					"slug": "Noxesium",
-					"version": "0.1.4",
-					"download_link": "https://cdn.modrinth.com/data/Kw7Sm3Xf/versions/WhRq6Q4n/noxesium-0.1.4.jar"
 				},
 				{
 					"slug": "Modern-Fix",
@@ -489,11 +494,6 @@
 					"slug": "Krypton",
 					"version": "0.1.9",
 					"download_link": "https://cdn.modrinth.com/data/fQEb0iXm/versions/0.1.9/krypton-0.1.9.jar"
-				},
-				{
-					"slug": "Mod-Menu",
-					"version": "3.2.5",
-					"download_link": "https://cdn.modrinth.com/data/mOgUt4GM/versions/nVxObSbX/modmenu-3.2.5.jar"
 				},
 				{
 					"slug": "Modern-Fix",

--- a/mods.json
+++ b/mods.json
@@ -17,8 +17,8 @@
 			"defaultMods": [
 				{
 					"slug": "Sodium",
-					"version": "0.5.8",
-					"download_link": "https://github.com/QuestCraftPlusPlus/sodium-fabric/releases/download/mc1.20.4-0.5.8/sodium-fabric-0.5.8+mc1.20.4.jar"
+					"version": "0.3.14",
+					"download_link": "https://cdn.modrinth.com/data/sk9rgfiA/versions/RHVugIok/embeddium-fabric-0.3.14%2Bmc1.20.4.jar"
 				},
 				{
 					"slug": "Cloth-Config",
@@ -49,6 +49,31 @@
 					"slug": "Modern-Fix",
 					"version": "5.10.0",
 					"download_link": "https://cdn.modrinth.com/data/nmDcB62a/versions/vxDb5tOq/modernfix-fabric-5.10.0%2Bmc1.20.3.jar"
+				},
+				{
+					"slug": "Noisium",
+					"version": "2.0.3",
+					"download_link": "https://cdn.modrinth.com/data/KuNKN7d2/versions/Eie3f6ki/noisium-fabric-2.0.3%2Bmc1.20.2-1.20.4.jar"
+				},
+				{
+					"slug": "Lithium",
+					"version": "0.12.1",
+					"download_link": "https://cdn.modrinth.com/data/gvQqBUqZ/versions/nMhjKWVE/lithium-fabric-mc1.20.4-0.12.1.jar"
+				},
+				{
+					"slug": "EntityCulling",
+					"version": "1.6.5",
+					"download_link": "https://cdn.modrinth.com/data/NNAgCjsB/versions/hyejM5za/entityculling-fabric-1.6.5-mc1.20.4.jar"
+				},
+				{
+					"slug": "Ferrite-Core",
+					"version": "6.0.3",
+					"download_link": "https://cdn.modrinth.com/data/uXXizFIs/versions/pguEMpy9/ferritecore-6.0.3-fabric.jar"
+				},
+				{
+					"slug": "Krypton",
+					"version": "0.2.6",
+					"download_link": "https://cdn.modrinth.com/data/fQEb0iXm/versions/bRcuOnao/krypton-0.2.6.jar"
 				}
 			]
 		},
@@ -108,11 +133,6 @@
 					"download_link": "https://cdn.modrinth.com/data/4WWQxlQP/versions/wgjsjWPu/servercore-fabric-1.5.0%2B1.20.2.jar"
 				},
 				{
-					"slug": "Mod-Menu",
-					"version": "8.0.0",
-					"download_link": "https://cdn.modrinth.com/data/mOgUt4GM/versions/TwfjidT5/modmenu-8.0.0.jar"
-				},
-				{
 					"slug": "ImmediatelyFast",
 					"version": "1.2.6",
 					"download_link": "https://cdn.modrinth.com/data/5ZwdcRci/versions/mbeaDZtb/ImmediatelyFast-1.2.6%2B1.20.2.jar"
@@ -126,6 +146,11 @@
 					"slug": "Modern-Fix",
 					"version": "5.9.0",
 					"download_link": "https://cdn.modrinth.com/data/nmDcB62a/versions/FDGaMHFj/modernfix-fabric-5.9.0%2Bmc1.20.1.jar"
+				},
+				{
+					"slug": "Noisium",
+					"version": "2.0.2",
+					"download_link": "https://cdn.modrinth.com/data/KuNKN7d2/versions/ZgEmwDsG/noisium-fabric-2.0.2%2Bmc1.20.2-1.20.4.jar"
 				}
 			]
 		},
@@ -151,8 +176,8 @@
 				},
 				{
 					"slug": "Ferrite-Core",
-					"version": "6.0.0",
-					"download_link": "https://cdn.modrinth.com/data/uXXizFIs/versions/FCnCG6PS/ferritecore-6.0.0-fabric.jar"
+					"version": "6.0.1",
+					"download_link": "https://cdn.modrinth.com/data/uXXizFIs/versions/unerR5MN/ferritecore-6.0.1-fabric.jar"
 				},
 				{
 					"slug": "Entity-Culling",
@@ -161,8 +186,8 @@
 				},
 				{
 					"slug": "Sodium",
-					"version": "0.5.8",
-					"download_link": "https://github.com/QuestCraftPlusPlus/sodium-fabric/releases/download/mc1.20.1-0.5.8/sodium-fabric-0.5.8+mc1.20.1.jar"
+					"version": "0.3.19",
+					"download_link": "https://cdn.modrinth.com/data/sk9rgfiA/versions/Xg1M092Q/embeddium-fabric-0.3.19%2Bmc1.20.1.jar"
 				},
 				{
 					"slug": "Cloth-Config",
@@ -190,11 +215,6 @@
 					"download_link": "https://cdn.modrinth.com/data/4WWQxlQP/versions/dXmFuxyH/servercore-fabric-1.5.0%2B1.20.1.jar"
 				},
 				{
-					"slug": "Mod-Menu",
-					"version": "7.0.1",
-					"download_link": "https://cdn.modrinth.com/data/mOgUt4GM/versions/RTFDnTKf/modmenu-7.0.1.jar"
-				},
-				{
 					"slug": "ImmediatelyFast",
 					"version": "1.1.15",
 					"download_link": "https://cdn.modrinth.com/data/5ZwdcRci/versions/4IDo27OL/ImmediatelyFast-1.1.15%2B1.20.1.jar"
@@ -208,6 +228,11 @@
 					"slug": "Modern-Fix",
 					"version": "5.9.0",
 					"download_link": "https://cdn.modrinth.com/data/nmDcB62a/versions/FDGaMHFj/modernfix-fabric-5.9.0%2Bmc1.20.1.jar"
+				},
+				{
+					"slug": "Noisium",
+					"version": "2.0.3",
+					"download_link": "https://cdn.modrinth.com/data/KuNKN7d2/versions/uTdy9g9c/noisium-fabric-2.0.3%2Bmc1.20-1.20.1.jar"
 				}
 			]
 		},
@@ -254,7 +279,7 @@
 				{
 					"slug": "Sodium",
 					"version": "0.4.10",
-					"download_link": "https://cdn.modrinth.com/data/AANobbMI/versions/b4hTi3mo/sodium-fabric-mc1.19.4-0.4.10%2Bbuild.24.jar"
+					"download_link": "https://github.com/QuestCraftPlusPlus/sodium-fabric/releases/download/mc1.19.4-0.4.11/sodium-fabric-mc1.19.4-0.4.11+build.1.jar"
 				},
 				{
 					"slug": "Cloth-Config",
@@ -292,19 +317,9 @@
 					"download_link": "https://cdn.modrinth.com/data/4WWQxlQP/versions/aq6o4qRe/servercore-1.3.5-1.19.4.jar"
 				},
 				{
-					"slug": "Mod-Menu",
-					"version": "6.2.1",
-					"download_link": "https://cdn.modrinth.com/data/mOgUt4GM/versions/yjjsLqbS/modmenu-6.2.1.jar"
-				},
-				{
 					"slug": "ImmediatelyFast",
 					"version": "1.1.12",
 					"download_link": "https://cdn.modrinth.com/data/5ZwdcRci/versions/8IFFeKYy/ImmediatelyFast-1.1.12%2B1.19.4.jar"
-				},
-				{
-					"slug": "Noxesium",
-					"version": "0.1.8",
-					"download_link": "https://cdn.modrinth.com/data/Kw7Sm3Xf/versions/5QKzTtlI/noxesium-0.1.8.jar"
 				},
 				{
 					"slug": "Modern-Fix",
@@ -379,11 +394,6 @@
 					"download_link": "https://cdn.modrinth.com/data/fQEb0iXm/versions/0.2.1/krypton-0.2.1.jar"
 				},
 				{
-					"slug": "Mod_Menu",
-					"version": "4.2.0-beta.2",
-					"download_link": "https://cdn.modrinth.com/data/mOgUt4GM/versions/gSoPJyVn/modmenu-4.2.0-beta.2.jar"
-				},
-				{
 					"slug": "Better-Biome-Blend",
 					"version": "1.3.6",
 					"download_link": "https://cdn.modrinth.com/data/Rs6c7WyL/versions/1.19.0-1.3.6/betterbiomeblend-1.19.0-1.3.6-fabric.jar"
@@ -392,11 +402,6 @@
 					"slug": "ImmediatelyFast",
 					"version": "1.1.12",
 					"download_link": "https://cdn.modrinth.com/data/5ZwdcRci/versions/4yVqQKQO/ImmediatelyFast-1.1.12%2B1.19.jar"
-				},
-				{
-					"slug": "Noxesium",
-					"version": "0.1.4",
-					"download_link": "https://cdn.modrinth.com/data/Kw7Sm3Xf/versions/WhRq6Q4n/noxesium-0.1.4.jar"
 				},
 				{
 					"slug": "Modern-Fix",
@@ -489,11 +494,6 @@
 					"slug": "Krypton",
 					"version": "0.1.9",
 					"download_link": "https://cdn.modrinth.com/data/fQEb0iXm/versions/0.1.9/krypton-0.1.9.jar"
-				},
-				{
-					"slug": "Mod-Menu",
-					"version": "3.2.5",
-					"download_link": "https://cdn.modrinth.com/data/mOgUt4GM/versions/nVxObSbX/modmenu-3.2.5.jar"
 				},
 				{
 					"slug": "Modern-Fix",

--- a/src/main/java/pojlib/util/JREUtils.java
+++ b/src/main/java/pojlib/util/JREUtils.java
@@ -197,7 +197,10 @@ public class JREUtils {
 
         userArgs.add("-XX:+UseZGC");
         userArgs.add("-XX:+ZGenerational");
-
+        userArgs.add("-XX:+UnlockExperimentalVMOptions");
+        userArgs.add("-XX:+UnlockDiagnosticVMOptions");
+        userArgs.add("-XX:+DisableExplicitGC");
+        userArgs.add("-XX:+UseCriticalJavaThreadPriority");
         userArgs.add("-Dorg.lwjgl.opengl.libname=" + graphicsLib);
         userArgs.add("-Dorg.lwjgl.opengles.libname=" + "/system/lib64/libGLESv3.so");
         userArgs.add("-Dorg.lwjgl.egl.libname=" + "/system/lib64/libEGL_dri.so");


### PR DESCRIPTION
https://github.com/QuestCraftPlusPlus/Pojlib/pull/44
JVM Args are listed here

This PR also adds Embeddium to .1 and .4 of 1.20's, with adding Noisium to all 20s and 
This also adds all prior mods to 1.20.4, which was in need.
Also removes modmenu because that is not meant to be there by default, only in devmods by default, but because most people are using devmods now i have to treat both the same.