### PR TITLE
Fix the OS

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: windows-2022
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Yes, its set to Windows for some ungodly reason, meaning that a _**BASH**_ command doesn't work _**obviously**_

- it does, just ignores bash?
- this commit is made for ubuntu, but in fixing submodules windows was selected for some odd reason.