### PR TITLE
Feature: Add support for Minecrafts Demo Mode

### DIFF
--- a/src/main/java/pojlib/InstanceHandler.java
+++ b/src/main/java/pojlib/InstanceHandler.java
@@ -295,4 +295,14 @@ public class InstanceHandler {
             e.printStackTrace();
         }
     }
+
+    public static void launchDemoInstance(Activity activity, MinecraftInstances.Instance instance) {
+        try {
+            JREUtils.redirectAndPrintJRELog();
+            VLoader.setAndroidInitInfo(activity);
+            JREUtils.launchJavaVM(activity, instance.generateDemoLaunchArgs(), instance);
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
+    }
 }

--- a/src/main/java/pojlib/util/json/MinecraftInstances.java
+++ b/src/main/java/pojlib/util/json/MinecraftInstances.java
@@ -60,7 +60,7 @@ public class MinecraftInstances {
         public List<String> generateDemoLaunchArgs() {
             String[] mcArgs = {"--username", "Demo", "--version", versionName, "--gameDir", gameDir,
                     "--assetsDir", assetsDir, "--assetIndex", assetIndex, "--uuid", "2437c2f918114fb9a96f99232c7dd25b",
-                    "--accessToken", "", "--userType", "mojang", "--versionType", "release"};
+                    "--accessToken", "", "--userType", "mojang", "--versionType", "release", "--demo"};
 
             List<String> allArgs = new ArrayList<>(Arrays.asList("-cp", classpath));
             allArgs.add(mainClass);

--- a/src/main/java/pojlib/util/json/MinecraftInstances.java
+++ b/src/main/java/pojlib/util/json/MinecraftInstances.java
@@ -57,6 +57,17 @@ public class MinecraftInstances {
             return allArgs;
         }
 
+        public List<String> generateDemoLaunchArgs() {
+            String[] mcArgs = {"--username", "Demo", "--version", versionName, "--gameDir", gameDir,
+                    "--assetsDir", assetsDir, "--assetIndex", assetIndex, "--uuid", "2437c2f918114fb9a96f99232c7dd25b",
+                    "--accessToken", "", "--userType", "mojang", "--versionType", "release"};
+
+            List<String> allArgs = new ArrayList<>(Arrays.asList("-cp", classpath));
+            allArgs.add(mainClass);
+            allArgs.addAll(Arrays.asList(mcArgs));
+            return allArgs;
+        }
+
         public ProjectInfo[] toArray() {
             if(extProjects == null) {
                 return new ProjectInfo[0];


### PR DESCRIPTION
This is a WIP implementation to support Demo mode, so people can try out QuestCraft without having to own Minecraft.

Demo mode will have some additional/removed features:
- Additional page to just start Demo mode without having to log in
- No mod- and resourcepack-manager for Demo mode
- Will only launch the latest available Minecraft version

I'm still cooking on this and will do testing on it, but any thoughts and recommendations on this are very welcome