### PR TITLE
Cap the auto-sized JVM heap against total device RAM

### DIFF
--- a/src/main/java/pojlib/util/JREUtils.java
+++ b/src/main/java/pojlib/util/JREUtils.java
@@ -40,6 +40,21 @@ public class JREUtils {
     private static String sNativeLibDir;
     private static String runtimeDir;
 
+    /** Smallest heap we will hand out, so the game can still start on a busy device. */
+    private static final long MIN_HEAP_MB = 1024;
+    /**
+     * Largest share of the device's total RAM the Java heap may take.
+     * <p>
+     * The heap is only one part of the process: the GL driver, the XR swapchains, LWJGL and the
+     * JRE itself need roughly as much again outside it, and the VR compositor and system services
+     * have to keep running or the low memory killer takes the game out. Sizing purely from free
+     * memory means a device that happens to launch with a lot free hands out a heap it cannot
+     * afford for the rest of the session.
+     */
+    private static final double MAX_HEAP_FRACTION = 0.25;
+    /** Heap committed at startup; the JVM grows towards -Xmx only as the game actually needs it. */
+    private static final long INITIAL_HEAP_MB = 512;
+
     public static String findInLdLibPath(String libName) {
         if(Os.getenv("LD_LIBRARY_PATH")==null) {
             try {
@@ -210,6 +225,20 @@ public class JREUtils {
         return true;
     }
 
+    /**
+     * Picks a max heap size that fits alongside everything else the process and the headset need.
+     *
+     * @param availMem memory currently free to the app, in MB
+     * @param totalMem the device's total RAM in MB
+     * @return the heap size to pass to -Xmx, in MB
+     */
+    static long clampHeap(long availMem, long totalMem) {
+        long ceiling = (long) (totalMem * MAX_HEAP_FRACTION);
+        // Never return less than the floor, even on a device small enough that the ceiling
+        // would fall below it, or the game cannot start at all.
+        return Math.max(MIN_HEAP_MB, Math.min(availMem, ceiling));
+    }
+
     public static int launchJavaVM(final Activity activity, final List<String> JVMArgs, MinecraftInstances.Instance instance) throws Throwable {
         final String graphicsLib = loadGraphicsLibrary();
         List<String> userArgs = getJavaArgs(activity, instance);
@@ -217,18 +246,21 @@ public class JREUtils {
         //Add automatically generated args
         if (API.customRAMValue) {
             Logger.getInstance().appendToLog("Setting JVM memory to " + API.memoryValue + "MB (Custom)");
-            userArgs.add("-Xms" + API.memoryValue + "M");
+            // Start small and let the heap grow into the value the user picked. Committing it all
+            // up front costs that memory even in sessions that never need it.
+            userArgs.add("-Xms" + INITIAL_HEAP_MB + "M");
             userArgs.add("-Xmx" + API.memoryValue + "M");
         } else {
             ActivityManager manager = (ActivityManager) activity.getSystemService(Activity.ACTIVITY_SERVICE);
             ActivityManager.MemoryInfo ami = new ActivityManager.MemoryInfo();
             manager.getMemoryInfo(ami);
             long availMem = (ami.availMem-ami.threshold)/(1024*1024);
-            long allocatedRam = Math.max(availMem, 1536);
+            long totalMem = ami.totalMem/(1024*1024);
+            long allocatedRam = clampHeap(availMem, totalMem);
 
             Logger.getInstance().appendToLog("Setting JVM memory to " + allocatedRam + "MB");
 
-            userArgs.add("-Xms" + 1024 + "M");
+            userArgs.add("-Xms" + Math.min(INITIAL_HEAP_MB, allocatedRam) + "M");
             userArgs.add("-Xmx" + allocatedRam + "M");
         }
 


### PR DESCRIPTION
## Problem

The auto path sizes the JVM heap purely from free memory:

```java
long availMem = (ami.availMem-ami.threshold)/(1024*1024);
long allocatedRam = Math.max(availMem, 1536);
```

That is a floor with no ceiling, so the more RAM is free at launch, the larger a heap
the game claims for the rest of the session. `874e85b` ("Fix ram setter") introduced
this when it replaced the previous bounded calculation, which did cap the result. On
this branch the `*= 0.8` discount is gone as well, so nothing tempers the reading at all.

The relationship is backwards on a headset. The heap is only part of the process — the
GL driver, XR swapchains, LWJGL and the JRE need roughly as much again outside it — and
the VR compositor and system services have to keep running or `lmkd` kills the game.

## Evidence

Measured on a 6GB Quest 2 (Horizon OS, MC 1.21.5 + Vivecraft):

| Free RAM at launch | Heap granted | Process PSS | Result |
|---|---|---|---|
| ~322 MB | 1536 MB | 3.1 GB | survived |
| ~3.5 GB | 2048 MB | 4.24 GB | repeated `reason=3 (LOW_MEMORY)` kills |

Having *more* memory free made the game less stable, not more. With the heap held to
1456 MB instead, the same device measured **3.12 GB PSS** and **754 MB** free, with no
LOW_MEMORY kills across ~21 hours and several sessions.

On this branch the same 3.5 GB-free launch would request roughly a **3300 MB** heap.

## Change

- Clamp `-Xmx` to a quarter of **total** RAM. This scales with the device rather than
  hardcoding a number, and makes the heap stable across launches instead of varying
  with whatever else happened to be running.
- Lower the startup commitment so the heap grows only as the game needs it, rather than
  committing 1024 MB in every session.
- Stop pinning `-Xms` to `-Xmx` on the custom path, where it forced the user's entire
  chosen value to be committed immediately.

Resulting caps: Quest 2 → 1458 MB, Quest 3 → ~1950 MB, 12GB Quest Pro → ~2925 MB.

The GC flags are deliberately untouched. `-XX:+UseZGC` carries real native overhead and
is a tempting target, but it was presumably chosen for frame-time consistency, which
matters more here than in a desktop game — that is a separate argument needing separate
evidence.

## Testing caveat

Compiles against `QuestCraft-6.0.1` (JDK 17). The on-device numbers above come from
patching the heap constants in the shipped QuestCraft 6.0.0 APK, whose Pojlib predates
`874e85b` — so they validate the *effect* of bounding the heap rather than this exact
code path. I do not have a Unity build environment to produce a full APK from this
branch; happy to adjust if you can run it through the normal pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
